### PR TITLE
Address pep8 discrepancies via black and autopep8

### DIFF
--- a/geom.py
+++ b/geom.py
@@ -3,73 +3,81 @@
 
 from functools import total_ordering
 
+
 @total_ordering
 class Point:
-	def __init__( self, x = 0, y = 0 ):
-		self.x = x
-		self.y = y
+    def __init__(self, x=0, y=0):
+        self.x = x
+        self.y = y
 
-	def __repr__( self ):
-		return '<{0} {1}>'.format( self.x, self.y )
+    def __repr__(self):
+        return "<{0} {1}>".format(self.x, self.y)
 
-	def __add__( self, other ):
-		return Point( self.x + other.x, self.y + other.y )
-	
-	def __sub__( self, other ):
-		return Point( self.x - other.x, self.y - other.y )
+    def __add__(self, other):
+        return Point(self.x + other.x, self.y + other.y)
 
-	def __mul__( self, d ):
-		return Point( self.x * d, self.y * d )
+    def __sub__(self, other):
+        return Point(self.x - other.x, self.y - other.y)
 
-	def __eq__( self, other ):
-		return (self.x == other.x) and (self.y == other.y)
+    def __mul__(self, d):
+        return Point(self.x * d, self.y * d)
 
-	def __lt__( self, other ):
-		if self.y < other.y:
-			return True
-		else:
-			return (self.y == other.y) and (self.x < other.x)
+    def __eq__(self, other):
+        return (self.x == other.x) and (self.y == other.y)
 
-	## Allow points to be stored in sets or used as keys in dictionaries
-	def __hash__( self ):
-		return hash( (self.x, self.y) )
+    def __lt__(self, other):
+        if self.y < other.y:
+            return True
+        else:
+            return (self.y == other.y) and (self.x < other.x)
+
+    ## Allow points to be stored in sets or used as keys in dictionaries
+    def __hash__(self):
+        return hash((self.x, self.y))
+
 
 ### The first two rows of a 3x3 2D affine transformation matrix, in
 ### row-major order (with 0 0 1 as the implicit third row).
 class Transform:
-	def __init__( self, a = 1, b = 0, c = 0, d = 0, e = 1, f = 0 ):
-		self.m = (a,b,c,d,e,f)
+    def __init__(self, a=1, b=0, c=0, d=0, e=1, f=0):
+        self.m = (a, b, c, d, e, f)
 
-	def __repr__( self ):
-		return '<{0},{1},{2},{3},{4},{5}>'.format( *self.m )
+    def __repr__(self):
+        return "<{0},{1},{2},{3},{4},{5}>".format(*self.m)
 
-	def __mul__( self, other ):
-		if isinstance( other, Transform ):
-			return Transform(
-				self.m[0] * other.m[0] + self.m[1] * other.m[3],
-				self.m[0] * other.m[1] + self.m[1] * other.m[4],
-				self.m[0] * other.m[2] + self.m[1] * other.m[5] + self.m[2],
-				self.m[3] * other.m[0] + self.m[4] * other.m[3],
-				self.m[3] * other.m[1] + self.m[4] * other.m[4],
-				self.m[3] * other.m[2] + self.m[4] * other.m[5] + self.m[5] )
-		else:
-			return Point( 
-				self.m[0] * other.x + self.m[1] * other.y + self.m[2],
-				self.m[3] * other.x + self.m[4] * other.y + self.m[5] )
-	
-	def invert( self ):
-		det = self.m[0] * self.m[4] - self.m[1] * self.m[3]
-		return Transform(
-			self.m[4] // det, -self.m[1] // det, 
-			(self.m[1] * self.m[5] - self.m[2] * self.m[4]) // det,
-			-self.m[3] // det, self.m[0] // det, 
-			(self.m[2] * self.m[3] - self.m[0] * self.m[5]) // det )
+    def __mul__(self, other):
+        if isinstance(other, Transform):
+            return Transform(
+                self.m[0] * other.m[0] + self.m[1] * other.m[3],
+                self.m[0] * other.m[1] + self.m[1] * other.m[4],
+                self.m[0] * other.m[2] + self.m[1] * other.m[5] + self.m[2],
+                self.m[3] * other.m[0] + self.m[4] * other.m[3],
+                self.m[3] * other.m[1] + self.m[4] * other.m[4],
+                self.m[3] * other.m[2] + self.m[4] * other.m[5] + self.m[5],
+            )
+        else:
+            return Point(
+                self.m[0] * other.x + self.m[1] * other.y + self.m[2],
+                self.m[3] * other.x + self.m[4] * other.y + self.m[5],
+            )
 
-	def __eq__( self, other ):
-		return self.m == other.m
+    def invert(self):
+        det = self.m[0] * self.m[4] - self.m[1] * self.m[3]
+        return Transform(
+            self.m[4] // det,
+            -self.m[1] // det,
+            (self.m[1] * self.m[5] - self.m[2] * self.m[4]) // det,
+            -self.m[3] // det,
+            self.m[0] // det,
+            (self.m[2] * self.m[3] - self.m[0] * self.m[5]) // det,
+        )
 
-	def __hash__( self ):
-		return hash( self.m )
-	
-def translate( x, y ):
-	return Transform( 1, 0, x, 0, 1, y )
+    def __eq__(self, other):
+        return self.m == other.m
+
+    def __hash__(self):
+        return hash(self.m)
+
+
+def translate(x, y):
+    return Transform(1, 0, x, 0, 1, y)

--- a/geom.py
+++ b/geom.py
@@ -1,5 +1,5 @@
-### Basic geometry classes: points and affine transformations with
-### integer coordinates.
+# Basic geometry classes: points and affine transformations with
+# integer coordinates.
 
 from functools import total_ordering
 
@@ -31,13 +31,13 @@ class Point:
         else:
             return (self.y == other.y) and (self.x < other.x)
 
-    ## Allow points to be stored in sets or used as keys in dictionaries
+    # Allow points to be stored in sets or used as keys in dictionaries
     def __hash__(self):
         return hash((self.x, self.y))
 
 
-### The first two rows of a 3x3 2D affine transformation matrix, in
-### row-major order (with 0 0 1 as the implicit third row).
+# The first two rows of a 3x3 2D affine transformation matrix, in
+# row-major order (with 0 0 1 as the implicit third row).
 class Transform:
     def __init__(self, a=1, b=0, c=0, d=0, e=1, f=0):
         self.m = (a, b, c, d, e, f)

--- a/hat.py
+++ b/hat.py
@@ -2,15 +2,18 @@ from geom import Point
 
 ### The coordinates of the kite cells that make up the hat polykite,
 ### given in the coordinate system defined in kitegrid.py.
-hat = set( [
-	Point( 0, -1 ),
-	Point( 1, -1 ),
-	Point( 1, 0 ),
-	Point( 0, 1 ),
-	Point( 1, 2 ),
-	Point( 2, 1 ),
-	Point( 3, -1 ),
-	Point( 4, -1 ) ] )
+hat = set(
+    [
+        Point(0, -1),
+        Point(1, -1),
+        Point(1, 0),
+        Point(0, 1),
+        Point(1, 2),
+        Point(2, 1),
+        Point(3, -1),
+        Point(4, -1),
+    ]
+)
 
 ## The hex cells of the *vertices* of the hat's outline. In the rest
 ## of the implementation of the kite grid we avoid referring explicitly
@@ -19,16 +22,17 @@ hat = set( [
 ## easily associate hexagons in the underlying hex tiling with all tiles
 ## *and* all vertices.
 hat_outline = [
-	Point(0, 0),
-	Point(-1,-1),
-	Point(0,-2),
-	Point(2,-2),
-	Point(2,-1),
-	Point(4,-2),
-	Point(5,-1),
-	Point(4, 0),
-	Point(3, 0),
-	Point(2, 2),
-	Point(0, 3),
-	Point(0, 2),
-	Point(-1, 2) ]
+    Point(0, 0),
+    Point(-1, -1),
+    Point(0, -2),
+    Point(2, -2),
+    Point(2, -1),
+    Point(4, -2),
+    Point(5, -1),
+    Point(4, 0),
+    Point(3, 0),
+    Point(2, 2),
+    Point(0, 3),
+    Point(0, 2),
+    Point(-1, 2),
+]

--- a/hat.py
+++ b/hat.py
@@ -1,7 +1,7 @@
 from geom import Point
 
-### The coordinates of the kite cells that make up the hat polykite,
-### given in the coordinate system defined in kitegrid.py.
+# The coordinates of the kite cells that make up the hat polykite,
+# given in the coordinate system defined in kitegrid.py.
 hat = set(
     [
         Point(0, -1),
@@ -15,12 +15,12 @@ hat = set(
     ]
 )
 
-## The hex cells of the *vertices* of the hat's outline. In the rest
-## of the implementation of the kite grid we avoid referring explicitly
-## to these vertex locations.  In other Laves grids they aren't
-## so easily described, but it just so happens that in [3.4.6.4] you can
-## easily associate hexagons in the underlying hex tiling with all tiles
-## *and* all vertices.
+# The hex cells of the *vertices* of the hat's outline. In the rest
+# of the implementation of the kite grid we avoid referring explicitly
+# to these vertex locations.  In other Laves grids they aren't
+# so easily described, but it just so happens that in [3.4.6.4] you can
+# easily associate hexagons in the underlying hex tiling with all tiles
+# *and* all vertices.
 hat_outline = [
     Point(0, 0),
     Point(-1, -1),

--- a/kitegrid.py
+++ b/kitegrid.py
@@ -9,157 +9,179 @@
 from geom import Point, Transform
 
 c_offsets = [
-	[None, Point(-1,0), None, None, None, Point(1,0)],
-	[None, Point(0,1), Point(-1,1), None, Point(1,-1), Point(0,-1)] ]
+    [None, Point(-1, 0), None, None, None, Point(1, 0)],
+    [None, Point(0, 1), Point(-1, 1), None, Point(1, -1), Point(0, -1)],
+]
 
 ## Rotate 60 degrees CCW
-R60 = Transform( 0, -1, 0, 1, 1, 0 )
+R60 = Transform(0, -1, 0, 1, 1, 0)
 ## Rotate 60 degrees CW
-R300 = Transform( 1, 1, 0, -1, 0, 0 )
+R300 = Transform(1, 1, 0, -1, 0, 0)
 
-def getSixfoldCentre( p ):
-	'''Every kite in the kite grid is adjacent to exactly one
-	centre of sixfold rotation.  Return that point.'''
-	return p + c_offsets[p.y%2][(p.x-p.y)%6]
 
-def canTranslate( p, q ):
-	'''Check whether p and q are related by a translation of the
-	kite grid.'''
-	return (p-getSixfoldCentre(p)) == (q-getSixfoldCentre(q))
+def getSixfoldCentre(p):
+    """Every kite in the kite grid is adjacent to exactly one
+    centre of sixfold rotation.  Return that point."""
+    return p + c_offsets[p.y % 2][(p.x - p.y) % 6]
 
-def getAdjacents( p ):
-	'''Get a set of the four kite cells that share an edge with p'''
-	c = getSixfoldCentre( p )
-	v = p - c
-	left = R60 * v
-	right = R300 * v
-	return set([c + left, c + right, p + v + left, p + v + right])
 
-def getNeighbours( p ):
-	'''Get a cyclic list of the nine kite cells that share an edge or a 
-	vertex with p, in cyclic order around the cell'''
-	c = getSixfoldCentre( p )
-	v = p - c
-	left = R60 * v
-	right = R300 * v
-	return [c + left, c - right, c - v, c - left, c + right,
-		p + right * 2, p + v + right, p + v + left, p + left * 2]
+def canTranslate(p, q):
+    """Check whether p and q are related by a translation of the
+    kite grid."""
+    return (p - getSixfoldCentre(p)) == (q - getSixfoldCentre(q))
 
-def getNeighbourSet( p ):
-	return set( getNeighbours( p ) )
 
-def getHalo( sop ):
-	'''Get a set of all the kite cells that are neighbours of any
-	cell in the set sop, excluding cells in sop itself'''
-	hset = set()
-	for p in sop:
-		ns = getNeighbourSet( p )
-		for n in ns:
-			hset.add( n )
-	return hset - sop
+def getAdjacents(p):
+    """Get a set of the four kite cells that share an edge with p"""
+    c = getSixfoldCentre(p)
+    v = p - c
+    left = R60 * v
+    right = R300 * v
+    return set([c + left, c + right, p + v + left, p + v + right])
 
-def getRainbow( p, h, sop ):
-	'''A helper function for getOrderedHalo().  Given cell p in shape
-	sop, get the arc of p's neighbours outside of sop that contains h.
-	Return the list of halo cells encountered and the first shape cell 
-	after them.'''
 
-	ns = getNeighbours( p )
-	i = ns.index( h ) + len(ns)
+def getNeighbours(p):
+    """Get a cyclic list of the nine kite cells that share an edge or a
+    vertex with p, in cyclic order around the cell"""
+    c = getSixfoldCentre(p)
+    v = p - c
+    left = R60 * v
+    right = R300 * v
+    return [
+        c + left,
+        c - right,
+        c - v,
+        c - left,
+        c + right,
+        p + right * 2,
+        p + v + right,
+        p + v + left,
+        p + left * 2,
+    ]
 
-	## Walk back to the first non-sop cell 
-	while ns[(i-1)%len(ns)] not in sop:
-		i = i - 1
 
-	ret = []
-	while ns[i%len(ns)] not in sop:
-		ret.append( ns[i%len(ns)] )
-		i = i + 1
+def getNeighbourSet(p):
+    return set(getNeighbours(p))
 
-	return (ret, ns[i%len(ns)])
 
-def getHaloStart( sop ):
-	'''Get a suitable starting cell for an ordered halo.  This is any
-	cell in sop that's adjacent to a cell not in sop across one of its
-	edges.  Return the cell and the halo neighbour.'''
+def getHalo(sop):
+    """Get a set of all the kite cells that are neighbours of any
+    cell in the set sop, excluding cells in sop itself"""
+    hset = set()
+    for p in sop:
+        ns = getNeighbourSet(p)
+        for n in ns:
+            hset.add(n)
+    return hset - sop
 
-	for p in sop:
-		ans = getAdjacents( p )
 
-		for a in ans:
-			if a not in sop:
-				return (p,a)
-				
-def getOrderedHalo( sop ):
-	'''Given a shape, get a cyclic list of all neighbouring kite cells 
-	that circle the border.  The list might omit cells that were
-	covered earlier, but that's OK.'''
+def getRainbow(p, h, sop):
+    """A helper function for getOrderedHalo().  Given cell p in shape
+    sop, get the arc of p's neighbours outside of sop that contains h.
+    Return the list of halo cells encountered and the first shape cell
+    after them."""
 
-	used = sop.copy()
+    ns = getNeighbours(p)
+    i = ns.index(h) + len(ns)
 
-	start, h = getHaloStart( sop )
+    ## Walk back to the first non-sop cell
+    while ns[(i - 1) % len(ns)] not in sop:
+        i = i - 1
 
-	cur = start
-	ret = []
+    ret = []
+    while ns[i % len(ns)] not in sop:
+        ret.append(ns[i % len(ns)])
+        i = i + 1
 
-	while True:
-		rainbow, next = getRainbow( cur, h, sop )
+    return (ret, ns[i % len(ns)])
 
-		## Add the subset of the rainbow that's not already used
-		for p in rainbow:
-			if not p in used:
-				ret.append( p )
-				used.add( p )
 
-		cur = next
-		h = rainbow[-1]
+def getHaloStart(sop):
+    """Get a suitable starting cell for an ordered halo.  This is any
+    cell in sop that's adjacent to a cell not in sop across one of its
+    edges.  Return the cell and the halo neighbour."""
 
-		if cur == start:
-			break
+    for p in sop:
+        ans = getAdjacents(p)
 
-	return ret
+        for a in ans:
+            if a not in sop:
+                return (p, a)
 
-def isSimplyConnected( sop ):
-	'''Check whether the set of kite cells given by sop is simply
-	connected'''
 
-	## This can be computed by checking that sop's halo is a single
-	## connected component relative to edge adjacencies.
-	halo = getHalo( sop )
-	visited = set()
+def getOrderedHalo(sop):
+    """Given a shape, get a cyclic list of all neighbouring kite cells
+    that circle the border.  The list might omit cells that were
+    covered earlier, but that's OK."""
 
-	## Pick a random halo element
-	p = next(iter(halo))
-	work = [p]
-	visited.add( p )
+    used = sop.copy()
 
-	## Depth first search
-	while len( work ) > 0:
-		p = work.pop()
-		ns = getAdjacents( p )
-		for n in ns:
-			if (n in halo) and (n not in visited):
-				visited.add( n )
-				work.append( n )
+    start, h = getHaloStart(sop)
 
-	## Did you visit the whole halo?
-	return len( visited ) == len( halo )
+    cur = start
+    ret = []
+
+    while True:
+        rainbow, next = getRainbow(cur, h, sop)
+
+        ## Add the subset of the rainbow that's not already used
+        for p in rainbow:
+            if not p in used:
+                ret.append(p)
+                used.add(p)
+
+        cur = next
+        h = rainbow[-1]
+
+        if cur == start:
+            break
+
+    return ret
+
+
+def isSimplyConnected(sop):
+    """Check whether the set of kite cells given by sop is simply
+    connected"""
+
+    ## This can be computed by checking that sop's halo is a single
+    ## connected component relative to edge adjacencies.
+    halo = getHalo(sop)
+    visited = set()
+
+    ## Pick a random halo element
+    p = next(iter(halo))
+    work = [p]
+    visited.add(p)
+
+    ## Depth first search
+    while len(work) > 0:
+        p = work.pop()
+        ns = getAdjacents(p)
+        for n in ns:
+            if (n in halo) and (n not in visited):
+                visited.add(n)
+                work.append(n)
+
+    ## Did you visit the whole halo?
+    return len(visited) == len(halo)
+
 
 def getAllOrientations():
-	'''Produce a list of 12 transformation matrices corresponding to 
-	all possible orientations of a shape in the kite grid'''
+    """Produce a list of 12 transformation matrices corresponding to
+    all possible orientations of a shape in the kite grid"""
 
-	## Reflect the hex grid across the X axis
-	Fy = Transform( 1, 1, 0, 0, -1, 0 )
+    ## Reflect the hex grid across the X axis
+    Fy = Transform(1, 1, 0, 0, -1, 0)
 
-	ret = []
-	T = Transform()
+    ret = []
+    T = Transform()
 
-	for i in range( 6 ):
-		ret.append( T )
-		ret.append( Fy * T )
-		T = R60 * T
+    for i in range(6):
+        ret.append(T)
+        ret.append(Fy * T)
+        T = R60 * T
 
-	return ret
+    return ret
+
 
 orientations = getAllOrientations()

--- a/kitegrid.py
+++ b/kitegrid.py
@@ -1,10 +1,10 @@
-### Manage cells in the [3.4.6.4] tiling using integer coordinates.
-### First, we give integer coordinates to the hexagons in the regular
-### [3^6] tiling, by giving coordinates relative to a basis with axes
-### (1,0) and (1/2,sqrt(3)/2).  Then we superimpose a scaled-up kite
-### tiling, so that every kite is uniquely associated with a hexagon
-### (and a fraction of the hexagons don't have a corresponding kite).
-### See the illustration in kitegrid.pdf.
+# Manage cells in the [3.4.6.4] tiling using integer coordinates.
+# First, we give integer coordinates to the hexagons in the regular
+# [3^6] tiling, by giving coordinates relative to a basis with axes
+# (1,0) and (1/2,sqrt(3)/2).  Then we superimpose a scaled-up kite
+# tiling, so that every kite is uniquely associated with a hexagon
+# (and a fraction of the hexagons don't have a corresponding kite).
+# See the illustration in kitegrid.pdf.
 
 from geom import Point, Transform
 
@@ -13,9 +13,9 @@ c_offsets = [
     [None, Point(0, 1), Point(-1, 1), None, Point(1, -1), Point(0, -1)],
 ]
 
-## Rotate 60 degrees CCW
+# Rotate 60 degrees CCW
 R60 = Transform(0, -1, 0, 1, 1, 0)
-## Rotate 60 degrees CW
+# Rotate 60 degrees CW
 R300 = Transform(1, 1, 0, -1, 0, 0)
 
 
@@ -84,7 +84,7 @@ def getRainbow(p, h, sop):
     ns = getNeighbours(p)
     i = ns.index(h) + len(ns)
 
-    ## Walk back to the first non-sop cell
+    # Walk back to the first non-sop cell
     while ns[(i - 1) % len(ns)] not in sop:
         i = i - 1
 
@@ -124,7 +124,7 @@ def getOrderedHalo(sop):
     while True:
         rainbow, next = getRainbow(cur, h, sop)
 
-        ## Add the subset of the rainbow that's not already used
+        # Add the subset of the rainbow that's not already used
         for p in rainbow:
             if not p in used:
                 ret.append(p)
@@ -143,17 +143,17 @@ def isSimplyConnected(sop):
     """Check whether the set of kite cells given by sop is simply
     connected"""
 
-    ## This can be computed by checking that sop's halo is a single
-    ## connected component relative to edge adjacencies.
+    # This can be computed by checking that sop's halo is a single
+    # connected component relative to edge adjacencies.
     halo = getHalo(sop)
     visited = set()
 
-    ## Pick a random halo element
+    # Pick a random halo element
     p = next(iter(halo))
     work = [p]
     visited.add(p)
 
-    ## Depth first search
+    # Depth first search
     while len(work) > 0:
         p = work.pop()
         ns = getAdjacents(p)
@@ -162,7 +162,7 @@ def isSimplyConnected(sop):
                 visited.add(n)
                 work.append(n)
 
-    ## Did you visit the whole halo?
+    # Did you visit the whole halo?
     return len(visited) == len(halo)
 
 
@@ -170,7 +170,7 @@ def getAllOrientations():
     """Produce a list of 12 transformation matrices corresponding to
     all possible orientations of a shape in the kite grid"""
 
-    ## Reflect the hex grid across the X axis
+    # Reflect the hex grid across the X axis
     Fy = Transform(1, 1, 0, 0, -1, 0)
 
     ret = []

--- a/matching.py
+++ b/matching.py
@@ -77,12 +77,12 @@ def withinClusterChecks(patch, labels):
     """Apply the within-cluster matching checks in Section 4.2 of the
     paper."""
 
-    ## Get the label for the central tile in the patch
+    # Get the label for the central tile in the patch
     cen = labels[Transform()]
 
     if cen == "H1":
-        ## Central tile is H1; need to check that neighbours H2, H3, and H4
-        ## are there.
+        # Central tile is H1; need to check that neighbours H2, H3, and H4
+        # are there.
         if labels[Transform(0, -1, -2, -1, 0, 4)] != "H2":
             print("H1 without an adjacent H2!")
             return False
@@ -120,10 +120,10 @@ def betweenClusterChecks(patch, labels):
     """Apply the between-cluster matching checks in Section 4.3 of
     the paper."""
 
-    ## Get the label for the central tile in the patch
+    # Get the label for the central tile in the patch
     cen = labels[Transform()]
 
-    ## H edge A+
+    # H edge A+
     if cen == "H2":
         if Transform(0, -1, -2, 1, 1, -2) in patch:
             if labels[Transform(0, -1, -2, 1, 1, -2)] not in ("T1", "P2"):
@@ -137,49 +137,49 @@ def betweenClusterChecks(patch, labels):
             print("H2 didn't have a valid A+ neighbour!")
             return False
 
-    ## H upper edge B-
+    # H upper edge B-
     if cen == "H1":
         if labels[Transform(-1, -1, 2, 0, 1, -4)] not in ("T1", "FP1"):
             print("H1 didn't have valid upper edge B- neighbour!")
             return False
 
-    ## H lower edge B-
+    # H lower edge B-
     if cen == "H3":
         if labels[Transform(1, 1, -2, -1, 0, -2)] not in ("T1", "FP1"):
             print("H3 didn't have valid lower edge B- neighbour!")
             return False
 
-    ## T upper edge A-
+    # T upper edge A-
     if cen == "T1":
         if labels[Transform(0, -1, 2, 1, 1, 2)] != "H2":
             print("T1 didn't have valid upper edge A- neighbour!")
             return False
 
-    ## T or P lower edge A-
+    # T or P lower edge A-
     if cen in ("T1", "P2"):
         if labels[Transform(1, 1, 4, -1, 0, -2)] != "H2":
             print("T or P didn't have valid lower edge A- neighbour!")
             return False
 
-    ## T, P or F edge B+
+    # T, P or F edge B+
     if cen in ("T1", "FP1"):
         if labels[Transform(1, 1, -4, -1, 0, 2)] not in ("H3", "H4"):
             print("T, P or F didn't have valid edge B+ neighbour!")
             return False
 
-    ## F edge F+
+    # F edge F+
     if cen == "F2":
         if labels[Transform(-1, -1, 8, 1, 0, -4)] != "F2":
             print("F didn't have valid edge F+ neighbour!")
             return False
 
-    ## F edge F-
+    # F edge F-
     if cen == "F2":
         if labels[Transform(0, 1, 4, -1, -1, 4)] != "F2":
             print("F didn't have valid edge F- neighbour!")
             return False
 
-    ## X+ edge at top of polykite
+    # X+ edge at top of polykite
     if cen in ("H2", "P2", "F2"):
         if Transform(0, 1, 0, -1, -1, 6) in patch:
             if labels[Transform(0, 1, 0, -1, -1, 6)] not in ("H2", "P2"):
@@ -193,7 +193,7 @@ def betweenClusterChecks(patch, labels):
             print("X+ top edge didn't have valid neighbour!")
             return False
 
-    ## X+ edge at right of polykite
+    # X+ edge at right of polykite
     if cen in ("H3", "H4", "FP1"):
         if Transform(-1, -1, 8, 1, 0, -4) in patch:
             if labels[Transform(-1, -1, 8, 1, 0, -4)] not in ("H2", "P2"):
@@ -207,7 +207,7 @@ def betweenClusterChecks(patch, labels):
             print("X+ right edge didn't have valid neighbour!")
             return False
 
-    ## X- edge at right of polykite
+    # X- edge at right of polykite
     if cen in ("H2", "P2"):
         if Transform(-1, -1, 6, 1, 0, 0) in patch:
             if labels[Transform(-1, -1, 6, 1, 0, 0)] not in ("H2", "F2", "P2"):
@@ -221,7 +221,7 @@ def betweenClusterChecks(patch, labels):
             print("X- right edge didn't have valid neighbour!")
             return False
 
-    ## X- edge at bottom of polykite
+    # X- edge at bottom of polykite
     if cen in ("H3", "H4", "FP1", "F2"):
         if Transform(1, 0, 2, 0, 1, -4) in patch:
             if labels[Transform(1, 0, 2, 0, 1, -4)] not in ("H2", "F2", "P2"):
@@ -235,7 +235,7 @@ def betweenClusterChecks(patch, labels):
             print("X- bottom edge didn't have valid neighbour!")
             return False
 
-    ## L edge at right of polykite
+    # L edge at right of polykite
     if cen == "P2":
         if Transform(-1, 0, 10, 0, -1, -2) in patch:
             if labels[Transform(-1, 0, 10, 0, -1, -2)] != "P2":
@@ -249,7 +249,7 @@ def betweenClusterChecks(patch, labels):
             print("L edge at right didn't have valid neighbour!")
             return False
 
-    ## L edge at bottom of polykite
+    # L edge at bottom of polykite
     if cen in ("FP1", "F2"):
         if Transform(0, -1, 0, 1, 1, -6) in patch:
             if labels[Transform(0, -1, 0, 1, 1, -6)] not in ("P2"):

--- a/matching.py
+++ b/matching.py
@@ -2,274 +2,285 @@ import sys
 
 from geom import Transform
 
-def readPatches( fin ):
-	'''Read an input file and extract all the patches.  Return a list of
-	dictionaries, where each dictionary maps transforms in the patch to
-	level (0 = kernel, 1 = first corona, 2 = second corona, etc.)'''
 
-	ret = []
-	while True:
-		l = fin.readline()
-		if len(l) == 0:
-			return ret
-		n = int( l )
-		patch = {}
+def readPatches(fin):
+    """Read an input file and extract all the patches.  Return a list of
+    dictionaries, where each dictionary maps transforms in the patch to
+    level (0 = kernel, 1 = first corona, 2 = second corona, etc.)"""
 
-		for i in range( n ):
-			l = fin.readline()
-			k = int(l[0])
-			xs = (int(x) for x in l[5:-2].split(','))
-			patch[ Transform( *xs ) ] = k
-		
-		ret.append( patch )
+    ret = []
+    while True:
+        l = fin.readline()
+        if len(l) == 0:
+            return ret
+        n = int(l)
+        patch = {}
 
-def getLabel( T, patch ):
-	'''Get the label for the tile at transform T in the given patch.'''
+        for i in range(n):
+            l = fin.readline()
+            k = int(l[0])
+            xs = (int(x) for x in l[5:-2].split(","))
+            patch[Transform(*xs)] = k
 
-	if T * Transform(1,1,2,0,-1,2) in patch:
-		return 'H1'
+        ret.append(patch)
 
-	if ((T * Transform(0,-1,4,-1,0,-2) in patch) and
-		(T * Transform(0,-1,8,1,1,-4) in patch)):
-		return 'H2'
 
-	if T * Transform(0,-1,-2,-1,0,4) in patch:
-		return 'H3'
+def getLabel(T, patch):
+    """Get the label for the tile at transform T in the given patch."""
 
-	if T * Transform(1,1,-4,0,-1,2) in patch:
-		return 'H4'
+    if T * Transform(1, 1, 2, 0, -1, 2) in patch:
+        return "H1"
 
-	if ((T * Transform(0,-1,2,1,1,2) in patch) and
-		(T * Transform(1,1,6,-1,0,0) in patch)):
-		return 'T1'
+    if (T * Transform(0, -1, 4, -1, 0, -2) in patch) and (
+        T * Transform(0, -1, 8, 1, 1, -4) in patch
+    ):
+        return "H2"
 
-	if ((T * Transform(-1,0,2,0,-1,-4) in patch) and
-		(T * Transform(1,1,4,-1,0,-2) in patch)):
-		return 'P2'
+    if T * Transform(0, -1, -2, -1, 0, 4) in patch:
+        return "H3"
 
-	if ((T * Transform(-1,-1,8,1,0,-4) in patch) and
-		(T * Transform(0,1,4,-1,-1,4) in patch)):
-		return 'F2'
+    if T * Transform(1, 1, -4, 0, -1, 2) in patch:
+        return "H4"
 
-	return 'FP1'
+    if (T * Transform(0, -1, 2, 1, 1, 2) in patch) and (
+        T * Transform(1, 1, 6, -1, 0, 0) in patch
+    ):
+        return "T1"
 
-def getPatchLabels( patch ):
-	'''Using the classification rules in Section 4 of the paper, build
-	a dictionary giving labels to all the transformation matrices in the
-	0- and 1-coronas of a 2-patch'''
+    if (T * Transform(-1, 0, 2, 0, -1, -4) in patch) and (
+        T * Transform(1, 1, 4, -1, 0, -2) in patch
+    ):
+        return "P2"
 
-	ret = {}
-	for T in patch.keys():
-		if patch[T] < 2:
-			ret[T] = getLabel( T, patch )
+    if (T * Transform(-1, -1, 8, 1, 0, -4) in patch) and (
+        T * Transform(0, 1, 4, -1, -1, 4) in patch
+    ):
+        return "F2"
 
-	return ret
+    return "FP1"
 
-def withinClusterChecks( patch, labels ):
-	'''Apply the within-cluster matching checks in Section 4.2 of the
-	paper.'''
 
-	## Get the label for the central tile in the patch
-	cen = labels[Transform()]
+def getPatchLabels(patch):
+    """Using the classification rules in Section 4 of the paper, build
+    a dictionary giving labels to all the transformation matrices in the
+    0- and 1-coronas of a 2-patch"""
 
-	if cen == 'H1':
-		## Central tile is H1; need to check that neighbours H2, H3, and H4
-		## are there.
-		if labels[ Transform(0,-1,-2,-1,0,4) ] != 'H2':
-			print( 'H1 without an adjacent H2!' )
-			return False
-		if labels[ Transform(0,-1,4,-1,0,-2) ] != 'H3':
-			print( 'H1 without an adjacent H3!' )
-			return False
-		if labels[ Transform(1,1,2,0,-1,2) ] != 'H4':
-			print( 'H1 without an adjacent H4!' )
-			return False
-	elif cen == 'H2':
-		if labels[ Transform(0,-1,4,-1,0,-2) ] != 'H1':
-			print( 'H3 without an adjacent H1!' )
-			return False
-	elif cen == 'H3':
-		if labels[ Transform(0,-1,-2,-1,0,4) ] != 'H1':
-			print( 'H3 without an adjacent H1!' )
-			return False
-	elif cen == 'H4':
-		if labels[ Transform(1,1,-4,0,-1,2) ] != 'H1':
-			print( 'H4 without an adjacent H1!' )
-			return False
-	elif cen == 'FP1':
-		if labels[ Transform(0,-1,2,1,1,2) ] not in ('P2', 'F2'):
-			print( 'FP1 without an adjacent P2 or F2!' )
-			return False
-	elif cen in ('P2', 'F2'):
-		if labels[ Transform(1,1,-4,-1,0,2) ] != 'FP1':
-			print( 'P2 or F2 without an adjacent FP1!' )
-			return False
+    ret = {}
+    for T in patch.keys():
+        if patch[T] < 2:
+            ret[T] = getLabel(T, patch)
 
-	return True
+    return ret
 
-def betweenClusterChecks( patch, labels ):
-	'''Apply the between-cluster matching checks in Section 4.3 of
-	the paper.'''
 
-	## Get the label for the central tile in the patch
-	cen = labels[Transform()]
+def withinClusterChecks(patch, labels):
+    """Apply the within-cluster matching checks in Section 4.2 of the
+    paper."""
 
-	## H edge A+
-	if cen == 'H2':
-		if Transform(0,-1,-2,1,1,-2) in patch:
-			if labels[Transform(0,-1,-2,1,1,-2)] not in ('T1', 'P2'):
-				print( 'H2 A+ neighbour (alt. 1) without valid label!' )
-				return False
-		elif Transform(1,1,-4,-1,0,2) in patch:
-			if labels[Transform(1,1,-4,-1,0,2)] != 'T1':
-				print( 'H2 A+ neighbour (alt. 2) without valid label!' )
-				return False
-		else:
-			print( 'H2 didn\'t have a valid A+ neighbour!' )
-			return False
+    ## Get the label for the central tile in the patch
+    cen = labels[Transform()]
 
-	## H upper edge B-
-	if cen == 'H1':
-		if labels[Transform(-1,-1,2,0,1,-4)] not in ('T1', 'FP1'):
-			print( 'H1 didn\'t have valid upper edge B- neighbour!' )
-			return False
+    if cen == "H1":
+        ## Central tile is H1; need to check that neighbours H2, H3, and H4
+        ## are there.
+        if labels[Transform(0, -1, -2, -1, 0, 4)] != "H2":
+            print("H1 without an adjacent H2!")
+            return False
+        if labels[Transform(0, -1, 4, -1, 0, -2)] != "H3":
+            print("H1 without an adjacent H3!")
+            return False
+        if labels[Transform(1, 1, 2, 0, -1, 2)] != "H4":
+            print("H1 without an adjacent H4!")
+            return False
+    elif cen == "H2":
+        if labels[Transform(0, -1, 4, -1, 0, -2)] != "H1":
+            print("H3 without an adjacent H1!")
+            return False
+    elif cen == "H3":
+        if labels[Transform(0, -1, -2, -1, 0, 4)] != "H1":
+            print("H3 without an adjacent H1!")
+            return False
+    elif cen == "H4":
+        if labels[Transform(1, 1, -4, 0, -1, 2)] != "H1":
+            print("H4 without an adjacent H1!")
+            return False
+    elif cen == "FP1":
+        if labels[Transform(0, -1, 2, 1, 1, 2)] not in ("P2", "F2"):
+            print("FP1 without an adjacent P2 or F2!")
+            return False
+    elif cen in ("P2", "F2"):
+        if labels[Transform(1, 1, -4, -1, 0, 2)] != "FP1":
+            print("P2 or F2 without an adjacent FP1!")
+            return False
 
-	## H lower edge B-
-	if cen == 'H3':
-		if labels[Transform(1,1,-2,-1,0,-2)] not in ('T1', 'FP1'):
-			print( 'H3 didn\'t have valid lower edge B- neighbour!' )
-			return False
-		
-	## T upper edge A-
-	if cen == 'T1':
-		if labels[Transform(0,-1,2,1,1,2)] != 'H2':
-			print( 'T1 didn\'t have valid upper edge A- neighbour!' )
-			return False
+    return True
 
-	## T or P lower edge A- 
-	if cen in ('T1', 'P2'):
-		if labels[Transform(1,1,4,-1,0,-2)] != 'H2':
-			print( 'T or P didn\'t have valid lower edge A- neighbour!' )
-			return False
 
-	## T, P or F edge B+
-	if cen in ('T1', 'FP1'):
-		if labels[Transform(1,1,-4,-1,0,2)] not in ('H3', 'H4'):
-			print( 'T, P or F didn\'t have valid edge B+ neighbour!' )
-			return False
+def betweenClusterChecks(patch, labels):
+    """Apply the between-cluster matching checks in Section 4.3 of
+    the paper."""
 
-	## F edge F+
-	if cen == 'F2':
-		if labels[Transform(-1,-1,8,1,0,-4)] != 'F2':
-			print( 'F didn\'t have valid edge F+ neighbour!' )
-			return False
-			
-	## F edge F-
-	if cen == 'F2':
-		if labels[Transform(0,1,4,-1,-1,4)] != 'F2':
-			print( 'F didn\'t have valid edge F- neighbour!' )
-			return False
+    ## Get the label for the central tile in the patch
+    cen = labels[Transform()]
 
-	## X+ edge at top of polykite
-	if cen in ('H2', 'P2', 'F2'):
-		if Transform(0,1,0,-1,-1,6) in patch:
-			if labels[Transform(0,1,0,-1,-1,6)] not in ('H2', 'P2'):
-				print( 'X+ top edge (alt. 1) didn\'t have valid neighbour!' )
-				return False
-		elif Transform(1,0,-2,0,1,4) in patch:
-			if labels[Transform(1,0,-2,0,1,4)] not in ('H3', 'H4', 'FP1', 'F2'):
-				print( 'X+ top edge (alt. 2) didn\'t have valid neighbour!' )
-				return False
-		else:
-			print( 'X+ top edge didn\'t have valid neighbour!' )
-			return False
+    ## H edge A+
+    if cen == "H2":
+        if Transform(0, -1, -2, 1, 1, -2) in patch:
+            if labels[Transform(0, -1, -2, 1, 1, -2)] not in ("T1", "P2"):
+                print("H2 A+ neighbour (alt. 1) without valid label!")
+                return False
+        elif Transform(1, 1, -4, -1, 0, 2) in patch:
+            if labels[Transform(1, 1, -4, -1, 0, 2)] != "T1":
+                print("H2 A+ neighbour (alt. 2) without valid label!")
+                return False
+        else:
+            print("H2 didn't have a valid A+ neighbour!")
+            return False
 
-	## X+ edge at right of polykite
-	if cen in ('H3', 'H4', 'FP1'):
-		if Transform(-1,-1,8,1,0,-4) in patch:
-			if labels[Transform(-1,-1,8,1,0,-4)] not in ('H2', 'P2'):
-				print( 'X+ right edge (alt. 1) didn\'t have valid neighbour!' )
-				return False
-		elif Transform(0,1,6,-1,-1,0) in patch:
-			if labels[Transform(0,1,6,-1,-1,0)] not in ('H3', 'H4', 'FP1', 'F2'):
-				print( 'X+ right edge (alt. 2) didn\'t have valid neighbour!' )
-				return False
-		else:
-			print( 'X+ right edge didn\'t have valid neighbour!' )
-			return False
+    ## H upper edge B-
+    if cen == "H1":
+        if labels[Transform(-1, -1, 2, 0, 1, -4)] not in ("T1", "FP1"):
+            print("H1 didn't have valid upper edge B- neighbour!")
+            return False
 
-	## X- edge at right of polykite
-	if cen in ('H2', 'P2'):
-		if Transform(-1,-1,6,1,0,0) in patch:
-			if labels[Transform(-1,-1,6,1,0,0)] not in ('H2', 'F2', 'P2'):
-				print( 'X- right edge (alt. 1) didn\'t have valid neighbour!' )
-				return False
-		elif Transform(0,1,4,-1,-1,4) in patch:
-			if labels[Transform(0,1,4,-1,-1,4)] not in ('H3', 'H4', 'FP1'):
-				print( 'X- right edge (alt. 2) didn\'t have valid neighbour!' )
-				return False
-		else:
-			print( 'X- right edge didn\'t have valid neighbour!' )
-			return False
+    ## H lower edge B-
+    if cen == "H3":
+        if labels[Transform(1, 1, -2, -1, 0, -2)] not in ("T1", "FP1"):
+            print("H3 didn't have valid lower edge B- neighbour!")
+            return False
 
-	## X- edge at bottom of polykite
-	if cen in ('H3', 'H4', 'FP1', 'F2'):
-		if Transform(1,0,2,0,1,-4) in patch:
-			if labels[Transform(1,0,2,0,1,-4)] not in ('H2', 'F2', 'P2'):
-				print( 'X- bottom edge (alt. 1) didn\'t have valid neighbour!' )
-				return False
-		elif Transform(-1,-1,6,1,0,-6) in patch:
-			if labels[Transform(-1,-1,6,1,0,-6)] not in ('H3', 'H4', 'FP1'):
-				print( 'X- bottom edge (alt. 2) didn\'t have valid neighbour!' )
-				return False
-		else:
-			print( 'X- bottom edge didn\'t have valid neighbour!' )
-			return False
-				
-	## L edge at right of polykite
-	if cen == 'P2':
-		if Transform(-1,0,10,0,-1,-2) in patch:
-			if labels[Transform(-1,0,10,0,-1,-2)] != 'P2':
-				print( 'L edge at right (alt. 1) didn\'t have valid neighbour!' )
-				return False
-		elif Transform(1,1,6,-1,0,0) in patch:
-			if labels[Transform(1,1,6,-1,0,0)] not in ('FP1', 'F2'):
-				print( 'L edge at right (alt. 2) didn\'t have valid neighbour!' )
-				return False
-		else:
-			print( 'L edge at right didn\'t have valid neighbour!' )
-			return False
+    ## T upper edge A-
+    if cen == "T1":
+        if labels[Transform(0, -1, 2, 1, 1, 2)] != "H2":
+            print("T1 didn't have valid upper edge A- neighbour!")
+            return False
 
-	## L edge at bottom of polykite
-	if cen in ('FP1', 'F2'):
-		if Transform(0,-1,0,1,1,-6) in patch:
-			if labels[Transform(0,-1,0,1,1,-6)] not in ('P2'):
-				print( 'L edge at bottom (alt. 1) didn\'t have valid neighbour!' )
-				return False
-		elif Transform(-1,0,2,0,-1,-4) in patch:
-			if labels[Transform(-1,0,2,0,-1,-4)] not in ('FP1', 'F2'):
-				print( 'L edge at bottom (alt. 2) didn\'t have valid neighbour!' )
-				return False
-		else:
-			print( 'L edge at bottom didn\'t have valid neighbour!' )
-			return False
+    ## T or P lower edge A-
+    if cen in ("T1", "P2"):
+        if labels[Transform(1, 1, 4, -1, 0, -2)] != "H2":
+            print("T or P didn't have valid lower edge A- neighbour!")
+            return False
 
-	return True
+    ## T, P or F edge B+
+    if cen in ("T1", "FP1"):
+        if labels[Transform(1, 1, -4, -1, 0, 2)] not in ("H3", "H4"):
+            print("T, P or F didn't have valid edge B+ neighbour!")
+            return False
 
-def processPatch( patch ):
-	labs = getPatchLabels( patch )
-	if not withinClusterChecks( patch, labs ):
-		return False
-	if not betweenClusterChecks( patch, labs ):
-		return False
-	return True
+    ## F edge F+
+    if cen == "F2":
+        if labels[Transform(-1, -1, 8, 1, 0, -4)] != "F2":
+            print("F didn't have valid edge F+ neighbour!")
+            return False
 
-if __name__ == '__main__':
-	passed = 0
+    ## F edge F-
+    if cen == "F2":
+        if labels[Transform(0, 1, 4, -1, -1, 4)] != "F2":
+            print("F didn't have valid edge F- neighbour!")
+            return False
 
-	patches = readPatches( sys.stdin )
-	for patch in patches:
-		if processPatch( patch ):
-			passed = passed + 1
+    ## X+ edge at top of polykite
+    if cen in ("H2", "P2", "F2"):
+        if Transform(0, 1, 0, -1, -1, 6) in patch:
+            if labels[Transform(0, 1, 0, -1, -1, 6)] not in ("H2", "P2"):
+                print("X+ top edge (alt. 1) didn't have valid neighbour!")
+                return False
+        elif Transform(1, 0, -2, 0, 1, 4) in patch:
+            if labels[Transform(1, 0, -2, 0, 1, 4)] not in ("H3", "H4", "FP1", "F2"):
+                print("X+ top edge (alt. 2) didn't have valid neighbour!")
+                return False
+        else:
+            print("X+ top edge didn't have valid neighbour!")
+            return False
 
-	print( '{0}/{1} patches passed checks'.format( passed, len(patches) ) )
+    ## X+ edge at right of polykite
+    if cen in ("H3", "H4", "FP1"):
+        if Transform(-1, -1, 8, 1, 0, -4) in patch:
+            if labels[Transform(-1, -1, 8, 1, 0, -4)] not in ("H2", "P2"):
+                print("X+ right edge (alt. 1) didn't have valid neighbour!")
+                return False
+        elif Transform(0, 1, 6, -1, -1, 0) in patch:
+            if labels[Transform(0, 1, 6, -1, -1, 0)] not in ("H3", "H4", "FP1", "F2"):
+                print("X+ right edge (alt. 2) didn't have valid neighbour!")
+                return False
+        else:
+            print("X+ right edge didn't have valid neighbour!")
+            return False
+
+    ## X- edge at right of polykite
+    if cen in ("H2", "P2"):
+        if Transform(-1, -1, 6, 1, 0, 0) in patch:
+            if labels[Transform(-1, -1, 6, 1, 0, 0)] not in ("H2", "F2", "P2"):
+                print("X- right edge (alt. 1) didn't have valid neighbour!")
+                return False
+        elif Transform(0, 1, 4, -1, -1, 4) in patch:
+            if labels[Transform(0, 1, 4, -1, -1, 4)] not in ("H3", "H4", "FP1"):
+                print("X- right edge (alt. 2) didn't have valid neighbour!")
+                return False
+        else:
+            print("X- right edge didn't have valid neighbour!")
+            return False
+
+    ## X- edge at bottom of polykite
+    if cen in ("H3", "H4", "FP1", "F2"):
+        if Transform(1, 0, 2, 0, 1, -4) in patch:
+            if labels[Transform(1, 0, 2, 0, 1, -4)] not in ("H2", "F2", "P2"):
+                print("X- bottom edge (alt. 1) didn't have valid neighbour!")
+                return False
+        elif Transform(-1, -1, 6, 1, 0, -6) in patch:
+            if labels[Transform(-1, -1, 6, 1, 0, -6)] not in ("H3", "H4", "FP1"):
+                print("X- bottom edge (alt. 2) didn't have valid neighbour!")
+                return False
+        else:
+            print("X- bottom edge didn't have valid neighbour!")
+            return False
+
+    ## L edge at right of polykite
+    if cen == "P2":
+        if Transform(-1, 0, 10, 0, -1, -2) in patch:
+            if labels[Transform(-1, 0, 10, 0, -1, -2)] != "P2":
+                print("L edge at right (alt. 1) didn't have valid neighbour!")
+                return False
+        elif Transform(1, 1, 6, -1, 0, 0) in patch:
+            if labels[Transform(1, 1, 6, -1, 0, 0)] not in ("FP1", "F2"):
+                print("L edge at right (alt. 2) didn't have valid neighbour!")
+                return False
+        else:
+            print("L edge at right didn't have valid neighbour!")
+            return False
+
+    ## L edge at bottom of polykite
+    if cen in ("FP1", "F2"):
+        if Transform(0, -1, 0, 1, 1, -6) in patch:
+            if labels[Transform(0, -1, 0, 1, 1, -6)] not in ("P2"):
+                print("L edge at bottom (alt. 1) didn't have valid neighbour!")
+                return False
+        elif Transform(-1, 0, 2, 0, -1, -4) in patch:
+            if labels[Transform(-1, 0, 2, 0, -1, -4)] not in ("FP1", "F2"):
+                print("L edge at bottom (alt. 2) didn't have valid neighbour!")
+                return False
+        else:
+            print("L edge at bottom didn't have valid neighbour!")
+            return False
+
+    return True
+
+
+def processPatch(patch):
+    labs = getPatchLabels(patch)
+    if not withinClusterChecks(patch, labs):
+        return False
+    if not betweenClusterChecks(patch, labs):
+        return False
+    return True
+
+
+if __name__ == "__main__":
+    passed = 0
+
+    patches = readPatches(sys.stdin)
+    for patch in patches:
+        if processPatch(patch):
+            passed = passed + 1
+
+    print("{0}/{1} patches passed checks".format(passed, len(patches)))

--- a/patchmap.py
+++ b/patchmap.py
@@ -1,5 +1,5 @@
 ### A data structure that keeps track of a set of transformations which
-### might be used as part of an n-patch, and a set of cells that make up 
+### might be used as part of an n-patch, and a set of cells that make up
 ### a current patch.  We also track, for all possible patch cells, which
 ### transformed tiles could potentially occupy those cells.  Used as part
 ### of recursively surrounding (n-1)-patches to construct n-patches.
@@ -7,69 +7,70 @@
 from hat import *
 from kitegrid import *
 
+
 class PatchMap:
-	def __init__( self, ts ):
-		self.shapes = {}
-		self.users = {}
-		self.occupied = set()
+    def __init__(self, ts):
+        self.shapes = {}
+        self.users = {}
+        self.occupied = set()
 
-		for T in ts:
-			ps = set([T * p for p in hat])
-			self.shapes[T] = ps
+        for T in ts:
+            ps = set([T * p for p in hat])
+            self.shapes[T] = ps
 
-			for P in ps:
-				self.users.setdefault( P, [] ).append( T )
+            for P in ps:
+                self.users.setdefault(P, []).append(T)
 
-	def copy( self ):
-		## Based on the recursive computation in surround.py, we need 
-		## a deep copy of the occupancy map, but we can keep the other
-		## information as-is (it won't be modified)
-		ret = PatchMap( [] )
-		ret.shapes = self.shapes
-		ret.users = self.users
-		ret.occupied = self.occupied.copy()
-		return ret
+    def copy(self):
+        ## Based on the recursive computation in surround.py, we need
+        ## a deep copy of the occupancy map, but we can keep the other
+        ## information as-is (it won't be modified)
+        ret = PatchMap([])
+        ret.shapes = self.shapes
+        ret.users = self.users
+        ret.occupied = self.occupied.copy()
+        return ret
 
-	def isOccupied( self, tp ):
-		'''Check if an individual cell, or if any of a list of cells, is
-		currently occupied.'''
+    def isOccupied(self, tp):
+        """Check if an individual cell, or if any of a list of cells, is
+        currently occupied."""
 
-		if isinstance( tp, Point ):
-			return tp in self.occupied
-		else:
-			ps = self.shapes[tp]
-			for P in ps:
-				if P in self.occupied:
-					return True
-			return False
+        if isinstance(tp, Point):
+            return tp in self.occupied
+        else:
+            ps = self.shapes[tp]
+            for P in ps:
+                if P in self.occupied:
+                    return True
+            return False
 
-	def setOccupied( self, tp ):
-		if isinstance( tp, Point ):
-			self.occupied.add( tp )
-		else:
-			ps = self.shapes[tp]
-			for P in ps:
-				self.occupied.add( P )
+    def setOccupied(self, tp):
+        if isinstance(tp, Point):
+            self.occupied.add(tp)
+        else:
+            ps = self.shapes[tp]
+            for P in ps:
+                self.occupied.add(P)
 
-	def setUnoccupied( self, tp ):
-		if isinstance( tp, Point ):
-			self.occupied.remove( tp )
-		else:
-			ps = self.shapes[tp]
-			for P in ps:
-				self.occupied.remove( P )
+    def setUnoccupied(self, tp):
+        if isinstance(tp, Point):
+            self.occupied.remove(tp)
+        else:
+            ps = self.shapes[tp]
+            for P in ps:
+                self.occupied.remove(P)
 
-	def isValid( self ):
-		'''Verify that a patch is legitimate.'''
+    def isValid(self):
+        """Verify that a patch is legitimate."""
 
-		## Must be simply connected.  That's basically it.
-		return isSimplyConnected( self.occupied )
+        ## Must be simply connected.  That's basically it.
+        return isSimplyConnected(self.occupied)
 
-	def getCells( self, T ):
-		return self.shapes[T]
+    def getCells(self, T):
+        return self.shapes[T]
 
-	def getUsers( self, P ):
-		return self.users[P]
+    def getUsers(self, P):
+        return self.users[P]
 
-	def getHalo( self ):
-		return getOrderedHalo( self.occupied )
+    def getHalo(self):
+        return getOrderedHalo(self.occupied)

--- a/patchmap.py
+++ b/patchmap.py
@@ -1,8 +1,8 @@
-### A data structure that keeps track of a set of transformations which
-### might be used as part of an n-patch, and a set of cells that make up
-### a current patch.  We also track, for all possible patch cells, which
-### transformed tiles could potentially occupy those cells.  Used as part
-### of recursively surrounding (n-1)-patches to construct n-patches.
+# A data structure that keeps track of a set of transformations which
+# might be used as part of an n-patch, and a set of cells that make up
+# a current patch.  We also track, for all possible patch cells, which
+# transformed tiles could potentially occupy those cells.  Used as part
+# of recursively surrounding (n-1)-patches to construct n-patches.
 
 from hat import *
 from kitegrid import *
@@ -22,9 +22,9 @@ class PatchMap:
                 self.users.setdefault(P, []).append(T)
 
     def copy(self):
-        ## Based on the recursive computation in surround.py, we need
-        ## a deep copy of the occupancy map, but we can keep the other
-        ## information as-is (it won't be modified)
+        # Based on the recursive computation in surround.py, we need
+        # a deep copy of the occupancy map, but we can keep the other
+        # information as-is (it won't be modified)
         ret = PatchMap([])
         ret.shapes = self.shapes
         ret.users = self.users
@@ -63,7 +63,7 @@ class PatchMap:
     def isValid(self):
         """Verify that a patch is legitimate."""
 
-        ## Must be simply connected.  That's basically it.
+        # Must be simply connected.  That's basically it.
         return isSimplyConnected(self.occupied)
 
     def getCells(self, T):

--- a/surround.py
+++ b/surround.py
@@ -9,9 +9,9 @@ def getLegalNeighbours(allow_holes=False):
     identity hat to a position and orientation that touches it
     without overlapping"""
 
-    ## For every orientation of the hat, translate each of its cells
-    ## to every halo cell of the identity hat.  If the result is
-    ## simply connected and doesn't overlap the identity hat, keep it.
+    # For every orientation of the hat, translate each of its cells
+    # to every halo cell of the identity hat.  If the result is
+    # simply connected and doesn't overlap the identity hat, keep it.
 
     halo = getHalo(hat)
     ret = set()
@@ -20,22 +20,22 @@ def getLegalNeighbours(allow_holes=False):
         o_hat = set([T * p for p in hat])
         for hp in halo:
             for op in o_hat:
-                ## Not all integer vectors are legal translations in
-                ## the kite grid.  Check only those that are.
+                # Not all integer vectors are legal translations in
+                # the kite grid.  Check only those that are.
                 if canTranslate(op, hp):
                     t_hat = set([p + (hp - op) for p in o_hat])
 
-                    ## t_hat is a candidate neighbour.  If it intersects
-                    ## the identity hat, we throw it away
+                    # t_hat is a candidate neighbour.  If it intersects
+                    # the identity hat, we throw it away
                     if not t_hat.isdisjoint(hat):
                         continue
 
-                    ## We also optionally need the union of the identity hat
-                    ## and t_hat to be simply connected.
+                    # We also optionally need the union of the identity hat
+                    # and t_hat to be simply connected.
                     if (not allow_holes) and (not isSimplyConnected(hat | t_hat)):
                         continue
 
-                    ## We have a legitimate neighbour!
+                    # We have a legitimate neighbour!
                     ret.add(translate(hp.x - op.x, hp.y - op.y) * T)
 
     return ret
@@ -59,25 +59,25 @@ def surroundFrom(pm, halo, patch, level):
     """Try to place a hat that covers the cells listed in the halo, in order.
     Maybe complete a surround, maybe backtrack."""
 
-    ## If there are no halo cells left to cover, we've got a surround.
+    # If there are no halo cells left to cover, we've got a surround.
     if len(halo) == 0:
         yield patch
         return
 
-    ## It's possible that we've already covered the first halo cell, in
-    ## which case just keep surrounding
+    # It's possible that we've already covered the first halo cell, in
+    # which case just keep surrounding
     if pm.isOccupied(halo[0]):
         yield from surroundFrom(pm, halo[1:], patch, level)
         return
 
-    ## If not, we try all ways to place a new tile to cover halo[0],
-    ## and recurse on each one.
+    # If not, we try all ways to place a new tile to cover halo[0],
+    # and recurse on each one.
 
     ts = pm.getUsers(halo[0])
     for T in ts:
         if not pm.isOccupied(T):
-            ## We can try to recurse on T, bracketed by setup and takedown
-            ## in the map
+            # We can try to recurse on T, bracketed by setup and takedown
+            # in the map
             pm.setOccupied(T)
             if pm.isValid():
                 yield from surroundFrom(pm, halo[1:], patch + [(level, T)], level)
@@ -91,13 +91,13 @@ def generateSurrounds(pm, patch):
 
     level = patch[-1][0] + 1
 
-    ## Get the ordered halo, giving us a plan for how to try to surround
-    ## the existing patch.
+    # Get the ordered halo, giving us a plan for how to try to surround
+    # the existing patch.
     halo = pm.getHalo()
 
-    ## Perform a simple sanity check first: if any halo cell has no
-    ## users compatible with the existing patch, then the patch isn't
-    ## surroundable.
+    # Perform a simple sanity check first: if any halo cell has no
+    # users compatible with the existing patch, then the patch isn't
+    # surroundable.
 
     for p in halo:
         found_compat = False
@@ -105,11 +105,11 @@ def generateSurrounds(pm, patch):
             if not pm.isOccupied(T):
                 found_compat = True
                 break
-        ## Nope, didn't find a usable tile in that position
+        # Nope, didn't find a usable tile in that position
         if not found_compat:
             return
 
-    ## Initiate the recursion!
+    # Initiate the recursion!
     yield from surroundFrom(pm, halo, patch, level)
 
 
@@ -123,36 +123,38 @@ if __name__ == "__main__":
     count = 0
     saved = 0
 
-    ## For our purposes, we'll never try to generate more than a 3-patch,
-    ## so it suffices to build a PatchMap based on 3-patches.
+    # For our purposes, we'll never try to generate more than a 3-patch,
+    # so it suffices to build a PatchMap based on 3-patches.
     pm = PatchMap(getPatchTransforms(3))
 
-    ## Always put the identity hat at the centre of the patch.
+    # Always put the identity hat at the centre of the patch.
     pm.setOccupied(Transform())
 
-    ## Generate all 1-patches
+    # Generate all 1-patches
     for tl in generateSurrounds(pm, [(0, Transform())]):
-        ## For each 1-patch, generate all 2-patches
+        # For each 1-patch, generate all 2-patches
         for tl2 in generateSurrounds(pm, tl):
             count = count + 1
             if count % 100 == 0:
                 sys.stderr.write(
-                    "Saw {0} 2-patches, {1} surroundable\n".format(count, saved)
+                    "Saw {0} 2-patches, {1} surroundable\n".format(
+                        count, saved)
                 )
 
-            ## Need a shallow copy of the patchmap so that we can discard
-            ## it without reverting
+            # Need a shallow copy of the patchmap so that we can discard
+            # it without reverting
             cpm = pm.copy()
 
-            ## Check for the existence of a 3-patch
+            # Check for the existence of a 3-patch
             for tl3 in generateSurrounds(cpm, tl2):
-                ## We found a 2-patch that was surroundable.  But we don't
-                ## actually care what 3-patch was generated.  Just output
-                ## the 2-patch and stop.
+                # We found a 2-patch that was surroundable.  But we don't
+                # actually care what 3-patch was generated.  Just output
+                # the 2-patch and stop.
                 outputPatch(tl2)
                 saved = saved + 1
-                ## Break here -- we're not trying to compute all 3-patches,
-                ## one is enough.
+                # Break here -- we're not trying to compute all 3-patches,
+                # one is enough.
                 break
 
-    sys.stderr.write("Total: {0} 2-patches, {1} surroundable\n".format(count, saved))
+    sys.stderr.write(
+        "Total: {0} 2-patches, {1} surroundable\n".format(count, saved))

--- a/surround.py
+++ b/surround.py
@@ -4,152 +4,155 @@ from geom import *
 from patchmap import *
 
 
-def getLegalNeighbours( allow_holes = False ):
-	'''Construct a set of transformation matrices that carry the
-	identity hat to a position and orientation that touches it 
-	without overlapping'''
+def getLegalNeighbours(allow_holes=False):
+    """Construct a set of transformation matrices that carry the
+    identity hat to a position and orientation that touches it
+    without overlapping"""
 
-	## For every orientation of the hat, translate each of its cells
-	## to every halo cell of the identity hat.  If the result is 
-	## simply connected and doesn't overlap the identity hat, keep it.
+    ## For every orientation of the hat, translate each of its cells
+    ## to every halo cell of the identity hat.  If the result is
+    ## simply connected and doesn't overlap the identity hat, keep it.
 
-	halo = getHalo( hat )
-	ret = set()
+    halo = getHalo(hat)
+    ret = set()
 
-	for T in orientations:
-		o_hat = set( [T * p for p in hat] )
-		for hp in halo:
-			for op in o_hat:
-				## Not all integer vectors are legal translations in
-				## the kite grid.  Check only those that are.
-				if canTranslate( op, hp ):
-					t_hat = set( [p + (hp-op) for p in o_hat] )
+    for T in orientations:
+        o_hat = set([T * p for p in hat])
+        for hp in halo:
+            for op in o_hat:
+                ## Not all integer vectors are legal translations in
+                ## the kite grid.  Check only those that are.
+                if canTranslate(op, hp):
+                    t_hat = set([p + (hp - op) for p in o_hat])
 
-					## t_hat is a candidate neighbour.  If it intersects
-					## the identity hat, we throw it away
-					if not t_hat.isdisjoint( hat ):
-						continue
+                    ## t_hat is a candidate neighbour.  If it intersects
+                    ## the identity hat, we throw it away
+                    if not t_hat.isdisjoint(hat):
+                        continue
 
-					## We also optionally need the union of the identity hat 
-					## and t_hat to be simply connected.
-					if (not allow_holes) and (not isSimplyConnected( hat | t_hat )):
-						continue
+                    ## We also optionally need the union of the identity hat
+                    ## and t_hat to be simply connected.
+                    if (not allow_holes) and (not isSimplyConnected(hat | t_hat)):
+                        continue
 
-					## We have a legitimate neighbour!
-					ret.add( translate(hp.x-op.x, hp.y-op.y) * T )
+                    ## We have a legitimate neighbour!
+                    ret.add(translate(hp.x - op.x, hp.y - op.y) * T)
 
-	return ret
+    return ret
 
-def getPatchTransforms( n ):
-	'''Get a set of transform matrices corresponding to all possible 
-	positions of a hat in an n-patch.'''
-	ret = set([Transform()])
-	ln = getLegalNeighbours()
 
-	for i in range( n ):
-		for T in list( ret ):
-			for S in ln:
-				ret.add( T * S )
+def getPatchTransforms(n):
+    """Get a set of transform matrices corresponding to all possible
+    positions of a hat in an n-patch."""
+    ret = set([Transform()])
+    ln = getLegalNeighbours()
 
-	return ret
+    for i in range(n):
+        for T in list(ret):
+            for S in ln:
+                ret.add(T * S)
 
-def surroundFrom( pm, halo, patch, level ):
-	'''Try to place a hat that covers the cells listed in the halo, in order.
-	Maybe complete a surround, maybe backtrack.'''
+    return ret
 
-	## If there are no halo cells left to cover, we've got a surround.
-	if len( halo ) == 0:
-		yield patch
-		return
 
-	## It's possible that we've already covered the first halo cell, in
-	## which case just keep surrounding
-	if pm.isOccupied( halo[0] ):
-		yield from surroundFrom( pm, halo[1:], patch, level )
-		return 
+def surroundFrom(pm, halo, patch, level):
+    """Try to place a hat that covers the cells listed in the halo, in order.
+    Maybe complete a surround, maybe backtrack."""
 
-	## If not, we try all ways to place a new tile to cover halo[0],
-	## and recurse on each one.
+    ## If there are no halo cells left to cover, we've got a surround.
+    if len(halo) == 0:
+        yield patch
+        return
 
-	ts = pm.getUsers( halo[0] )
-	for T in ts:
-		if not pm.isOccupied( T ):
-			## We can try to recurse on T, bracketed by setup and takedown
-			## in the map
-			pm.setOccupied( T )
-			if pm.isValid():
-				yield from surroundFrom(
-					pm, halo[1:], patch + [(level,T)], level )
-			pm.setUnoccupied( T )
+    ## It's possible that we've already covered the first halo cell, in
+    ## which case just keep surrounding
+    if pm.isOccupied(halo[0]):
+        yield from surroundFrom(pm, halo[1:], patch, level)
+        return
 
-def generateSurrounds( pm, patch ):
-	'''Given the partially used patch map in pm, generate a sequence
-	of all of the ways to surround it with hats.  Note the "generate": 
-	use this function as a value to iterate on.'''
+    ## If not, we try all ways to place a new tile to cover halo[0],
+    ## and recurse on each one.
 
-	level = patch[-1][0] + 1
+    ts = pm.getUsers(halo[0])
+    for T in ts:
+        if not pm.isOccupied(T):
+            ## We can try to recurse on T, bracketed by setup and takedown
+            ## in the map
+            pm.setOccupied(T)
+            if pm.isValid():
+                yield from surroundFrom(pm, halo[1:], patch + [(level, T)], level)
+            pm.setUnoccupied(T)
 
-	## Get the ordered halo, giving us a plan for how to try to surround
-	## the existing patch.
-	halo = pm.getHalo()
 
-	## Perform a simple sanity check first: if any halo cell has no 
-	## users compatible with the existing patch, then the patch isn't
-	## surroundable.
+def generateSurrounds(pm, patch):
+    """Given the partially used patch map in pm, generate a sequence
+    of all of the ways to surround it with hats.  Note the "generate":
+    use this function as a value to iterate on."""
 
-	for p in halo:
-		found_compat = False
-		for T in pm.getUsers( p ):
-			if not pm.isOccupied( T ):
-				found_compat = True
-				break
-		## Nope, didn't find a usable tile in that position
-		if not found_compat:
-			return
+    level = patch[-1][0] + 1
 
-	## Initiate the recursion!
-	yield from surroundFrom( pm, halo, patch, level )
+    ## Get the ordered halo, giving us a plan for how to try to surround
+    ## the existing patch.
+    halo = pm.getHalo()
 
-def outputPatch( ts ):
-	print( len( ts ) )
-	for k, T in ts:
-		print( '{0} ; {1}'.format( k, T ) )
+    ## Perform a simple sanity check first: if any halo cell has no
+    ## users compatible with the existing patch, then the patch isn't
+    ## surroundable.
 
-if __name__ == '__main__':
-	count = 0
-	saved = 0
+    for p in halo:
+        found_compat = False
+        for T in pm.getUsers(p):
+            if not pm.isOccupied(T):
+                found_compat = True
+                break
+        ## Nope, didn't find a usable tile in that position
+        if not found_compat:
+            return
 
-	## For our purposes, we'll never try to generate more than a 3-patch,
-	## so it suffices to build a PatchMap based on 3-patches.
-	pm = PatchMap( getPatchTransforms( 3 ) )
+    ## Initiate the recursion!
+    yield from surroundFrom(pm, halo, patch, level)
 
-	## Always put the identity hat at the centre of the patch.
-	pm.setOccupied( Transform() )
 
-	## Generate all 1-patches
-	for tl in generateSurrounds( pm, [(0,Transform())] ):
-		## For each 1-patch, generate all 2-patches
-		for tl2 in generateSurrounds( pm, tl ):
-			count = count + 1
-			if count % 100 == 0:
-				sys.stderr.write( 
-					'Saw {0} 2-patches, {1} surroundable\n'.format( 
-						count, saved ) )
+def outputPatch(ts):
+    print(len(ts))
+    for k, T in ts:
+        print("{0} ; {1}".format(k, T))
 
-			## Need a shallow copy of the patchmap so that we can discard
-			## it without reverting
-			cpm = pm.copy()
 
-			## Check for the existence of a 3-patch
-			for tl3 in generateSurrounds( cpm, tl2 ):
-				## We found a 2-patch that was surroundable.  But we don't
-				## actually care what 3-patch was generated.  Just output
-				## the 2-patch and stop.
-				outputPatch( tl2 )
-				saved = saved + 1
-				## Break here -- we're not trying to compute all 3-patches,
-				## one is enough.
-				break
+if __name__ == "__main__":
+    count = 0
+    saved = 0
 
-	sys.stderr.write( 
-		'Total: {0} 2-patches, {1} surroundable\n'.format( count, saved ) )
+    ## For our purposes, we'll never try to generate more than a 3-patch,
+    ## so it suffices to build a PatchMap based on 3-patches.
+    pm = PatchMap(getPatchTransforms(3))
+
+    ## Always put the identity hat at the centre of the patch.
+    pm.setOccupied(Transform())
+
+    ## Generate all 1-patches
+    for tl in generateSurrounds(pm, [(0, Transform())]):
+        ## For each 1-patch, generate all 2-patches
+        for tl2 in generateSurrounds(pm, tl):
+            count = count + 1
+            if count % 100 == 0:
+                sys.stderr.write(
+                    "Saw {0} 2-patches, {1} surroundable\n".format(count, saved)
+                )
+
+            ## Need a shallow copy of the patchmap so that we can discard
+            ## it without reverting
+            cpm = pm.copy()
+
+            ## Check for the existence of a 3-patch
+            for tl3 in generateSurrounds(cpm, tl2):
+                ## We found a 2-patch that was surroundable.  But we don't
+                ## actually care what 3-patch was generated.  Just output
+                ## the 2-patch and stop.
+                outputPatch(tl2)
+                saved = saved + 1
+                ## Break here -- we're not trying to compute all 3-patches,
+                ## one is enough.
+                break
+
+    sys.stderr.write("Total: {0} 2-patches, {1} surroundable\n".format(count, saved))

--- a/viz_neighbours.py
+++ b/viz_neighbours.py
@@ -6,74 +6,83 @@ from surround import getLegalNeighbours
 from hat import hat_outline
 
 sc = 10
-v1 = (sc,0)
-v2 = (0.5*sc,0.5*sc*math.sqrt(3))
+v1 = (sc, 0)
+v2 = (0.5 * sc, 0.5 * sc * math.sqrt(3))
 
-def getHatOutline( T ):
-	ret = []
-	for p in hat_outline:
-		tp = T * p
-		x = tp.x*v1[0] + tp.y*v2[0]
-		y = tp.x*v1[1] + tp.y*v2[1]
-		ret.append( (x, y) )
-	return ret
 
-def drawPolygon( fout, pgon, tx, ty, r, g, b ):
-	cmd = 'moveto'
-	for p in pgon:
-		x = tx + p[0]
-		y = ty + p[1]
-		fout.write( '{0} {1} {2}\n'.format( x, y, cmd ) )
-		cmd = 'lineto'
+def getHatOutline(T):
+    ret = []
+    for p in hat_outline:
+        tp = T * p
+        x = tp.x * v1[0] + tp.y * v2[0]
+        y = tp.x * v1[1] + tp.y * v2[1]
+        ret.append((x, y))
+    return ret
 
-	fout.write( 'closepath gsave {0} {1} {2} setrgbcolor fill grestore stroke newpath\n'.format( r, g, b ) )
 
-def samplePage( x, y ):
-	return (72 + x*(6.5*72/3.0), 10*72 - y*(9*72/4.0))
+def drawPolygon(fout, pgon, tx, ty, r, g, b):
+    cmd = "moveto"
+    for p in pgon:
+        x = tx + p[0]
+        y = ty + p[1]
+        fout.write("{0} {1} {2}\n".format(x, y, cmd))
+        cmd = "lineto"
 
-if __name__ == '__main__':
-	ts = getLegalNeighbours( True )
+    fout.write(
+        "closepath gsave {0} {1} {2} setrgbcolor fill grestore stroke newpath\n".format(
+            r, g, b
+        )
+    )
 
-	fout = sys.stdout
 
-	fout.write( '''%!PS-Adobe-3.0
+def samplePage(x, y):
+    return (72 + x * (6.5 * 72 / 3.0), 10 * 72 - y * (9 * 72 / 4.0))
+
+
+if __name__ == "__main__":
+    ts = getLegalNeighbours(True)
+
+    fout = sys.stdout
+
+    fout.write(
+        """%!PS-Adobe-3.0
 
 1 setlinewidth 0 setgray
 /Helvetica findfont
 12 scalefont
 setfont
 /cshow { dup stringwidth pop -0.5 mul 0 rmoveto show } def
-''' )
+"""
+    )
 
-	id_hat = getHatOutline( Transform() )
-	
-	x = 0
-	y = 0
+    id_hat = getHatOutline(Transform())
 
-	for T in ts:
-		t_hat = getHatOutline( T )
-		xmin = min( p[0] for p in id_hat + t_hat )
-		xmax = max( p[0] for p in id_hat + t_hat )
-		ymin = min( p[1] for p in id_hat + t_hat )
-		ymax = max( p[1] for p in id_hat + t_hat )
+    x = 0
+    y = 0
 
-		tx, ty = samplePage( x+0.5, y+0.5 )
-		tx = tx - 0.5*(xmin+xmax)
-		ty = ty - 0.5*(ymin+ymax)
+    for T in ts:
+        t_hat = getHatOutline(T)
+        xmin = min(p[0] for p in id_hat + t_hat)
+        xmax = max(p[0] for p in id_hat + t_hat)
+        ymin = min(p[1] for p in id_hat + t_hat)
+        ymax = max(p[1] for p in id_hat + t_hat)
 
-		drawPolygon( fout, id_hat, tx, ty, 0.5, 0.8, 0.5 )
-		drawPolygon( fout, t_hat, tx, ty, 0.75, 0.75, 0.75 )
+        tx, ty = samplePage(x + 0.5, y + 0.5)
+        tx = tx - 0.5 * (xmin + xmax)
+        ty = ty - 0.5 * (ymin + ymax)
 
-		tx, ty = samplePage( x+0.5, y+0.3 )
-		fout.write( '{0} {1} moveto ({2}) cshow\n'.format(
-			tx, ty - 100, T ) )
+        drawPolygon(fout, id_hat, tx, ty, 0.5, 0.8, 0.5)
+        drawPolygon(fout, t_hat, tx, ty, 0.75, 0.75, 0.75)
 
-		x = x + 1
-		if x == 3:
-			x = 0
-			y = y + 1
-			if y == 4:
-				y = 0
-				fout.write( 'showpage\n' )
+        tx, ty = samplePage(x + 0.5, y + 0.3)
+        fout.write("{0} {1} moveto ({2}) cshow\n".format(tx, ty - 100, T))
 
-	fout.write( 'showpage\n%%EOF\n' )
+        x = x + 1
+        if x == 3:
+            x = 0
+            y = y + 1
+            if y == 4:
+                y = 0
+                fout.write("showpage\n")
+
+    fout.write("showpage\n%%EOF\n")


### PR DESCRIPTION
I know code formatting can be a touchy subject, but most of the projects I'm familiar with appreciate the way that use of common tooling can make the code layout and conventions familiar to a broad swath of developers. The result tends to be less distracting, as well as addressing various issues that IDEs like PyCharm emit by default.

To get rid of nearly all the rest of the IDE notifications, this PR is the result of running the widely-used tools `black` and `autopep8`.

There are no logic changes here, and the commands in the README still seem to work fine.